### PR TITLE
Implement example synthetic form generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,3 +302,21 @@ FormSynthAI is an intelligent synthetic form data generation system designed to 
 ---
 
 *This document serves as the primary reference for FormSynthAI system development and should be updated as requirements evolve.*
+## Quick Start Demo
+
+A small demo script is provided to showcase synthetic form generation using the `formsynth` package.
+
+1. Create a blank form template in the `examples` directory:
+
+```bash
+python examples/create_blank_form.py
+```
+
+2. Generate a filled form based on `sample_config.json`:
+
+```bash
+python -m formsynth.generator examples/sample_config.json output.png
+```
+
+Add `--handwritten` to apply a handwriting-style effect and `--font` to supply a custom TrueType font.
+

--- a/examples/create_blank_form.py
+++ b/examples/create_blank_form.py
@@ -1,0 +1,10 @@
+"""Create a simple blank form template for demonstration."""
+from PIL import Image, ImageDraw
+
+width, height = 400, 300
+img = Image.new('RGB', (width, height), 'white')
+draw = ImageDraw.Draw(img)
+for y in [60, 100, 140, 180, 220]:
+    draw.line([(50, y+10), (350, y+10)], fill='black')
+img.save('blank_form.png')
+print('Created blank_form.png')

--- a/examples/sample_config.json
+++ b/examples/sample_config.json
@@ -1,0 +1,10 @@
+{
+  "template_path": "examples/blank_form.png",
+  "fields": {
+    "Full Name": {"x": 100, "y": 60, "font_size": 18},
+    "Address": {"x": 100, "y": 100, "font_size": 18},
+    "Date of Birth": {"x": 100, "y": 140, "font_size": 18},
+    "Email": {"x": 100, "y": 180, "font_size": 18},
+    "Phone": {"x": 100, "y": 220, "font_size": 18}
+  }
+}

--- a/formsynth/generator.py
+++ b/formsynth/generator.py
@@ -1,0 +1,86 @@
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+from PIL import Image, ImageDraw, ImageFont
+from faker import Faker
+
+faker = Faker()
+
+
+def load_config(path: str) -> Dict[str, Any]:
+    """Load configuration file describing form template and fields."""
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def generate_value(name: str) -> str:
+    """Generate synthetic value based on field name heuristics."""
+    lname = name.lower()
+    if 'name' in lname:
+        return faker.name()
+    if 'address' in lname:
+        return faker.address().replace('\n', ' ')
+    if 'date' in lname:
+        return faker.date_of_birth(minimum_age=18, maximum_age=90).strftime('%Y-%m-%d')
+    if 'phone' in lname:
+        return faker.phone_number()
+    if 'email' in lname:
+        return faker.email()
+    return faker.word()
+
+
+def render_field(draw: ImageDraw.Draw, text: str, x: int, y: int,
+                 font_path: str = None, font_size: int = 20,
+                 handwritten: bool = False) -> None:
+    """Render a text field at a given position."""
+    if font_path:
+        font = ImageFont.truetype(font_path, font_size)
+    else:
+        font = ImageFont.load_default()
+    if handwritten:
+        # Apply slight rotation for handwriting effect
+        tmp = Image.new('RGBA', draw.im.size, (255, 255, 255, 0))
+        tdraw = ImageDraw.Draw(tmp)
+        tdraw.text((x, y), text, fill='black', font=font)
+        rotated = tmp.rotate(faker.pyfloat(min_value=-2, max_value=2), resample=Image.BICUBIC)
+        draw.bitmap((0, 0), rotated, rotated)
+    else:
+        draw.text((x, y), text, fill='black', font=font)
+
+
+def generate_form(config_path: str, output_path: str,
+                  handwritten: bool = False, font_path: str = None) -> None:
+    cfg = load_config(config_path)
+    template_path = Path(cfg['template_path'])
+    image = Image.open(template_path).convert('RGBA')
+    draw = ImageDraw.Draw(image)
+
+    for field_name, params in cfg['fields'].items():
+        text = generate_value(field_name)
+        x = params.get('x', 0)
+        y = params.get('y', 0)
+        size = params.get('font_size', 20)
+        render_field(draw, text, x, y, font_path=font_path,
+                     font_size=size, handwritten=handwritten)
+
+    image.convert('RGB').save(output_path)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Generate synthetic filled form')
+    parser.add_argument('config', help='Path to JSON config describing fields')
+    parser.add_argument('output', help='Output image path')
+    parser.add_argument('--handwritten', action='store_true',
+                        help='Render text with handwriting effect')
+    parser.add_argument('--font', help='Optional TrueType font path')
+    args = parser.parse_args()
+
+    generate_form(args.config, args.output, handwritten=args.handwritten,
+                  font_path=args.font)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Pillow
+Faker


### PR DESCRIPTION
## Summary
- add a minimal `formsynth` package
- provide example config and blank form generation helper
- document quick start demo
- declare Pillow and Faker dependencies

## Testing
- `python -m py_compile formsynth/generator.py examples/create_blank_form.py`

------
https://chatgpt.com/codex/tasks/task_e_684d92da8094832bb1387c0cb2359f05